### PR TITLE
Fix failed population of `PICO_EXTRAS_PATH` when fetched from git

### DIFF
--- a/pico_extras_import.cmake
+++ b/pico_extras_import.cmake
@@ -26,14 +26,14 @@ if (NOT PICO_EXTRAS_PATH)
             get_filename_component(FETCHCONTENT_BASE_DIR "${PICO_EXTRAS_FETCH_FROM_GIT_PATH}" REALPATH BASE_DIR "${CMAKE_SOURCE_DIR}")
         endif ()
         FetchContent_Declare(
-                PICO_EXTRAS
+                pico_extras
                 GIT_REPOSITORY https://github.com/raspberrypi/pico-extras
                 GIT_TAG master
         )
-        if (NOT PICO_EXTRAS)
+        if (NOT pico_extras)
             message("Downloading PICO EXTRAS")
-            FetchContent_Populate(PICO_EXTRAS)
-            set(PICO_EXTRAS_PATH ${PICO_EXTRAS_SOURCE_DIR})
+            FetchContent_Populate(pico_extras)
+            set(PICO_EXTRAS_PATH ${pico_extras_SOURCE_DIR})
         endif ()
         set(FETCHCONTENT_BASE_DIR ${FETCHCONTENT_BASE_DIR_SAVE})
     else ()


### PR DESCRIPTION
When running cmake with
```
cmake -B build -DPICO_SDK_FETCH_FROM_GIT=y -DPICO_EXTRAS_FETCH_FROM_GIT=y
```

configuration fails because `PICO_EXTRAS_PATH` incorrectly points to `build` rather than `build/_deps/pico_extras-src`.