### PR TITLE
Include `playground_auto_set_url`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 .vscode
 cmake-*
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ include(pico_sdk_import.cmake)
 # We also need PICO EXTRAS
 include(pico_extras_import.cmake)
 
-# Include example_auto_set_url
-include(example_auto_set_url.cmake)
+# Include playground_auto_set_url
+include(playground_auto_set_url.cmake)
 
 project(pico_playground C CXX)
 set(CMAKE_C_STANDARD 11)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,9 @@ include(pico_sdk_import.cmake)
 # We also need PICO EXTRAS
 include(pico_extras_import.cmake)
 
+# Include example_auto_set_url
+include(example_auto_set_url.cmake)
+
 project(pico_playground C CXX)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ include(pico_sdk_import.cmake)
 # We also need PICO EXTRAS
 include(pico_extras_import.cmake)
 
+set(PICO_PLAYGROUND_PATH ${PROJECT_SOURCE_DIR})
 # Include playground_auto_set_url
 include(playground_auto_set_url.cmake)
 

--- a/example_auto_set_url.cmake
+++ b/example_auto_set_url.cmake
@@ -1,0 +1,5 @@
+set(PICO_EXTRAS_URL_BASE "https://github.com/raspberrypi/pico-extras/tree/HEAD")
+macro(example_auto_set_url TARGET)
+    file(RELATIVE_PATH URL_REL_PATH "${PICO_EXTRAS_PATH}" "${CMAKE_CURRENT_LIST_DIR}")
+    pico_set_program_url(${TARGET} "${PICO_EXTRAS_URL_BASE}/${URL_REL_PATH}")
+endmacro()

--- a/playground_auto_set_url.cmake
+++ b/playground_auto_set_url.cmake
@@ -1,5 +1,5 @@
-set(PICO_EXTRAS_URL_BASE "https://github.com/raspberrypi/pico-playground/tree/HEAD")
+set(PICO_PLAYGROUND_URL_BASE "https://github.com/raspberrypi/pico-playground/tree/HEAD")
 macro(playground_auto_set_url TARGET)
-    file(RELATIVE_PATH URL_REL_PATH "${PICO_EXTRAS_PATH}" "${CMAKE_CURRENT_LIST_DIR}")
-    pico_set_program_url(${TARGET} "${PICO_EXTRAS_URL_BASE}/${URL_REL_PATH}")
+    file(RELATIVE_PATH URL_REL_PATH "${PICO_PLAYGROUND_PATH}" "${CMAKE_CURRENT_LIST_DIR}")
+    pico_set_program_url(${TARGET} "${PICO_PLAYGROUND_URL_BASE}/${URL_REL_PATH}")
 endmacro()

--- a/playground_auto_set_url.cmake
+++ b/playground_auto_set_url.cmake
@@ -1,5 +1,5 @@
 set(PICO_EXTRAS_URL_BASE "https://github.com/raspberrypi/pico-extras/tree/HEAD")
-macro(example_auto_set_url TARGET)
+macro(playground_auto_set_url TARGET)
     file(RELATIVE_PATH URL_REL_PATH "${PICO_EXTRAS_PATH}" "${CMAKE_CURRENT_LIST_DIR}")
     pico_set_program_url(${TARGET} "${PICO_EXTRAS_URL_BASE}/${URL_REL_PATH}")
 endmacro()

--- a/playground_auto_set_url.cmake
+++ b/playground_auto_set_url.cmake
@@ -1,4 +1,4 @@
-set(PICO_EXTRAS_URL_BASE "https://github.com/raspberrypi/pico-extras/tree/HEAD")
+set(PICO_EXTRAS_URL_BASE "https://github.com/raspberrypi/pico-playground/tree/HEAD")
 macro(playground_auto_set_url TARGET)
     file(RELATIVE_PATH URL_REL_PATH "${PICO_EXTRAS_PATH}" "${CMAKE_CURRENT_LIST_DIR}")
     pico_set_program_url(${TARGET} "${PICO_EXTRAS_URL_BASE}/${URL_REL_PATH}")

--- a/reset/hello_reset/CMakeLists.txt
+++ b/reset/hello_reset/CMakeLists.txt
@@ -10,5 +10,5 @@ if (TARGET hardware_reset)
     pico_add_extra_outputs(hello_reset)
 
     # add url via pico_set_program_url
-    example_auto_set_url(hello_reset)
+    playground_auto_set_url(hello_reset)
 endif ()


### PR DESCRIPTION
Fixes #46

Include modified version of [`example_auto_set_url.cmake`](https://github.com/raspberrypi/pico-examples/blob/master/example_auto_set_url.cmake) to be able to use `example_auto_set_url` 