### PR TITLE
fixed typo for build instructions

### DIFF
--- a/apps/popcorn/converter/README.md
+++ b/apps/popcorn/converter/README.md
@@ -6,7 +6,7 @@ To build the converter, either do a `PICO_PLATFORM=host` build of pico-playgroun
 or from this directory just do
 
 ```bash
-mkidr build
+mkdir build
 cd build
 cmake -DCMAKE_BUILD_TYPE=Release ..
 make


### PR DESCRIPTION
There is a typo in the instructions that may cause a command not found error when the line is copied and pasted.
mkidr build

I changed it to fix the type.
mkdir build
The command should work when copied and pasted.