### PR TITLE
Reorder audio_format fields in sine_wave.c to match declaration of audio_format_t in pico-extras audio.h

### DIFF
--- a/audio/sine_wave/sine_wave.c
+++ b/audio/sine_wave/sine_wave.c
@@ -39,12 +39,12 @@ static int16_t sine_wave_table[SINE_WAVE_TABLE_LEN];
 struct audio_buffer_pool *init_audio() {
 
     static audio_format_t audio_format = {
-            .format = AUDIO_BUFFER_FORMAT_PCM_S16,
 #if USE_AUDIO_SPDIF
             .sample_freq = 44100,
 #else
             .sample_freq = 24000,
 #endif
+            .format = AUDIO_BUFFER_FORMAT_PCM_S16,
             .channel_count = 1,
     };
 


### PR DESCRIPTION
I reordered the audio_format fields in sine_wave.c to match the [type declaration of audio_format_t](https://github.com/raspberrypi/pico-extras/blob/master/src/common/pico_audio/include/pico/audio.h#L48) in pico-extras audio.h

This is particularly usefull if a user wants to use C++ instead of C as the wrong ordering will throw the following error at compile time:

```
error: designator order for field 'audio_format::sample_freq' does not match declaration order in 'audio_format_t' {aka 'audio_format'}
```